### PR TITLE
Allow support for gradients

### DIFF
--- a/.storybook/themes.json
+++ b/.storybook/themes.json
@@ -13,9 +13,10 @@
         "secondary-text": "#fff",
         "secondary-container": "#2f4af8",
         "secondary-light": "#465eff",
-        "secondary-dark": "#465eff",  
+        "secondary-dark": "#465eff",
         "secondary-hover": "#465eff",
         "background": "#fcfc30",
+        "background-gradient": "linear-gradient(to right, var(--secondary), var(--secondary-dark))",
         "text": "#000"
       }
     },
@@ -33,14 +34,15 @@
         "secondary-text": "#f3eef6",
         "secondary-container": "#7c5096",
         "secondary-light": "#d0bddc",
-        "secondary-dark": "#533564",  
+        "secondary-dark": "#533564",
         "secondary-hover": "#533564",
         "background": "#fcfc30",
+        "background-gradient": "linear-gradient(to right, var(--secondary), var(--secondary-dark))",
         "text": "#000"
       }
     },
     {
-      "name": "Theme Tree",
+      "name": "Theme Three",
       "miniLogo": "https://www.gclaims.com.br/assets/images/favicon/favicon-16x16.png",
       "tokens": {
         "primary": "#00a8ff",
@@ -53,9 +55,10 @@
         "secondary-text": "#e6faf6",
         "secondary-container": "#00c9a8",
         "secondary-light": "#4dd9c2",
-        "secondary-dark": "#00977e",  
+        "secondary-dark": "#00977e",
         "secondary-hover": "#00b597",
         "background": "#fcfc30",
+        "background-gradient": "linear-gradient(to right, var(--primary), var(--primary-dark))",
         "text": "#000"
       }
     }

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -52,6 +52,10 @@ export const ItemSelected = styled.div((props: {shadow?: boolean}) => ({
   'span': {
     fontSize: 13
   },
+  'svg': {
+    width: 14,
+    marginRight: 2
+  },
   'img': {
     width: 16,
     height: 16,

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -2,7 +2,7 @@ import { PARAM_KEY } from "../constants";
 import { ThemeType } from "./types";
 
 export function DisplayToolState(selector: string, state: { isInDocs: boolean, themeVariableCss: string | number, themeSelected: ThemeType  }) {
-  
+
   const queryTag = document.querySelector(`#${PARAM_KEY}`);
   const validate = !!state.themeVariableCss && !!state.themeSelected
   if(!validate) {
@@ -26,12 +26,12 @@ export function DisplayToolState(selector: string, state: { isInDocs: boolean, t
   setStyle(listVariables)
 }
 
-export function MountedVariables(theme: ThemeType) { 
+export function MountedVariables(theme: ThemeType) {
   const list =  theme.tokens ? Object.keys(theme.tokens) : [];
   return list.map((item: string) => {
     if(item.slice(0,2) === '--') {
       return `${item}: ${theme.tokens[item]}`
     }
     return `--${item}: ${theme.tokens[item]}`
-  }).toString().replace(/,/g,';');
+  }).join('; ');
 }

--- a/stories/Button.js
+++ b/stories/Button.js
@@ -7,7 +7,7 @@ import "./button.css";
  */
 export const Button = (props) => {
   const { theme = 'primary', label = 'Button' } = props;
-  
+
   return (
     <button
       type="button"
@@ -23,7 +23,7 @@ Button.propTypes = {
   /**
    * How large should the button be?
    */
-  theme: PropTypes.oneOf(["primary", "secondary"]),
+  theme: PropTypes.oneOf(["primary", "secondary", "outline"]),
   /**
    * Button contents
    */

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -4,7 +4,7 @@ import { Button } from "./Button";
 export default {
   title: "Example/Button",
   component: Button,
-  parameters: { 
+  parameters: {
     layout: 'centered',
   }
 };
@@ -13,4 +13,7 @@ const Template = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
 
-
+export const Outline = Template.bind({});
+Outline.args = {
+  theme: 'outline',
+};

--- a/stories/button.css
+++ b/stories/button.css
@@ -10,10 +10,17 @@
   padding: 11px 20px;
 }
 .theme-primary {
-  color: var(--primary-text);;
+  color: var(--primary-text);
   background-color: var(--primary-container);
 }
 .theme-secondary {
-  color: var(--secondary-text);;
+  color: var(--secondary-text);
   background-color: var(--secondary-container);
+}
+.theme-outline {
+  color: var(--text);
+  background: none;
+  border: 5px solid;
+  border-image-source: var(--background-gradient);
+  border-image-slice: 1;
 }


### PR DESCRIPTION
## Changes

1. Allow gradients in themes, or more specifically don't replace all commas in variables so anything that uses a comma will still work. See: https://github.com/raulmelo/addon-variablecss-theme/issues/1

**Before**
<img width="672" alt="Screen Shot 2022-10-10 at 11 28 04 am" src="https://user-images.githubusercontent.com/287178/194793032-4f433fe5-12c9-40fc-8a1a-ae867fd07b89.png">

**After**
<img width="675" alt="Screen Shot 2022-10-10 at 1 48 49 pm" src="https://user-images.githubusercontent.com/287178/194793024-8dc5dd25-3f90-4209-9fe1-2f56da0f4195.png">


2. Added an outline button to demo gradient support
 
<img width="857" alt="Screen Shot 2022-10-10 at 12 06 12 pm" src="https://user-images.githubusercontent.com/287178/194792783-7cc3a497-7a70-435d-b39f-a20e616648bc.png">


3. The lightning icon in Firefox didn't scale so I've added the default storybook icon width to it

**Before**
<img width="501" alt="Screen Shot 2022-10-10 at 11 18 35 am" src="https://user-images.githubusercontent.com/287178/194792826-bb9fe9ec-4292-45be-a404-a90456b596ba.png">

**After**
<img width="552" alt="Screen Shot 2022-10-10 at 12 08 07 pm" src="https://user-images.githubusercontent.com/287178/194792856-11e4b2c2-e7c8-415e-8c4b-048463a659db.png">

