### PR TITLE
chore: logo addons change

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
       "svelte",
       "web-components"
     ],
-    "icon": "https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png"
+    "icon": "https://raw.githubusercontent.com/raulmelo/addon-variablecss-theme/main/_docs/designtokensStorybook.png"
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.12--canary.7.2bcf7e4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @outlinestudio/designtokenscss@1.0.12--canary.7.2bcf7e4.0
  # or 
  yarn add @outlinestudio/designtokenscss@1.0.12--canary.7.2bcf7e4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
