### PR TITLE
docs: update README to require Storybook >=10

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ create components with variables css, based on the theme you want to use.
 
 ## Requirements
 
-- Storybook@>=6.0.0
+- Storybook@>=10
 
   This addon should work well with any framework: If you find the case the addon not works, please open an issue.
 


### PR DESCRIPTION
### Motivation
- Bump the documented minimum Storybook version to reflect compatibility with newer Storybook releases and avoid confusion about supported versions by stating `Storybook@>=10`.

### Description
- Replace the previous `Storybook@>=6.0.0` requirement with `Storybook@>=10` in `README.md` to clarify the supported Storybook version.

### Testing
- This is a documentation-only change and no automated tests were run for this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23aeeaa608832cb4cbfa5fe7343760)